### PR TITLE
Binder support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM jupyter/tensorflow-notebook:59b402ce701d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,5 @@
 FROM jupyter/tensorflow-notebook:59b402ce701d
+
+USER $NB_USER
+
+ADD . $HOME/repo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # HSR2019
 All material for the proposed 2 lectures in Data Engineering
+
+## Enter online environment for excercises
+
+:warning: This may perform **slower** than your local computer and is **only provided as a fall-back option**. :warning:
+
+Click the following badge to launch Jupyter Lab with Python 3 & TensorFlow on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/smurve/HSR2019/master?urlpath=lab)


### PR DESCRIPTION
- Makes this repo usable on mybinder.org by providing a docker image definition containing all required software (except for `apache_beam`, which will be used in the demos in the lecture, but not in the exercises).
- Adds a Badge to repo description allowing to launch Jupyter Lab on mybinder.org

Note: The URL the badge links to will only become functional if/when these changes land in the `master` branch of https://github.com/smurve/HSR2019. (E.g., when this PR is being merged.) To test this setup before that, https://mybinder.org/v2/gh/geometalab/HSR2019/binder?urlpath=lab can be used instead.